### PR TITLE
cast store_id to int, as methods are expecting int value not string

### DIFF
--- a/Plugin/Invoice.php
+++ b/Plugin/Invoice.php
@@ -56,7 +56,7 @@ class Invoice
     ) {
 
         $order = $subject->getOrder();
-        $storeId = $order->getStoreId();
+        $storeId = (int) $order->getStoreId();
         if (!$this->configRepository->isBackendEventEnabled(ConfigRepository::PURCHASE_EVENT, $storeId)) {
             return $result;
         }

--- a/Plugin/Subscriber.php
+++ b/Plugin/Subscriber.php
@@ -75,7 +75,7 @@ class Subscriber
      */
     private function executeBackendEvent(Subject $subscriber)
     {
-        $storeId = $subscriber->getStoreId();
+        $storeId = (int) $subscriber->getStoreId();
         if (!$this->configRepository->isBackendEventEnabled(ConfigRepository::EMAIL_OPT_IN_EVENT, $storeId)) {
             return;
         }

--- a/Service/ProcessingQueue/Processors/Order.php
+++ b/Service/ProcessingQueue/Processors/Order.php
@@ -78,7 +78,7 @@ class Order
             );
             $this->requestRepository->sendToPlatform(
                 $this->transformOrderData($order),
-                $order->getStoreId()
+                (int) $order->getStoreId()
             );
         } catch (\Exception $exception) {
             $this->logRepository->addErrorLog('Purchase event', $exception->getMessage());


### PR DESCRIPTION
Hello, this PR should fix several errors introduced in the last releases. There are several inconsistencies when using the store_id value.

Some methods are expecting an int, and when using the getData() method the value is a string. Otherwise, the backend events won't be processed.

Thank you!